### PR TITLE
Altered the core functionality to discard double-type inputs

### DIFF
--- a/src/main/java/malcolm/alasdair/raindropsutil/StringOutputBuilder.java
+++ b/src/main/java/malcolm/alasdair/raindropsutil/StringOutputBuilder.java
@@ -1,7 +1,5 @@
 package malcolm.alasdair.raindropsutil;
 
-import static java.lang.Integer.parseInt;
-
 public class StringOutputBuilder {
 
     private String output = "";
@@ -9,11 +7,11 @@ public class StringOutputBuilder {
 
     public StringOutputBuilder(String input) {
         try{
-            this.input = parseInt(input);
+            this.input = Integer.parseInt(input);
             createOutput();
         }
         catch(NumberFormatException e){
-            this.output = "Please enter a valid input";
+            this.output = "Please enter a valid, integer, input";
         }
     }
 

--- a/src/test/java/malcolm/alasdair/stepdefs/RaindropsStepDefs.java
+++ b/src/test/java/malcolm/alasdair/stepdefs/RaindropsStepDefs.java
@@ -6,8 +6,6 @@ import io.cucumber.java.en.When;
 import malcolm.alasdair.raindrops.Raindrops;
 import org.junit.jupiter.api.Assertions;
 
-import static java.lang.Integer.parseInt;
-
 public class RaindropsStepDefs {
 
     Raindrops raindropsClass;

--- a/src/test/resources/RaindropsResponseVariesForNonMultiples.feature
+++ b/src/test/resources/RaindropsResponseVariesForNonMultiples.feature
@@ -13,17 +13,17 @@ Feature: The application's response varies when the input is not a multiple of 3
   Scenario: The Raindrops application receives a string input, containing non-numerical characters
     Given An input of "Hello, I am an irritating input!"
     When The application is run
-    Then The output should be "Please enter a valid input"
+    Then The output should be "Please enter a valid, integer, input"
 
   Scenario: The Raindrops application receives an empty input
     Given An empty input
     When The application is run
-    Then The output should be "Please enter a valid input"
+    Then The output should be "Please enter a valid, integer, input"
 
   Scenario: The Raindrops application receives a null input
     Given A null input
     When The application is run
-    Then The output should be "Please enter a valid input"
+    Then The output should be "Please enter a valid, integer, input"
 
   Scenario: The Raindrops application receives a string input, equal to zero
     Given An input of "0"

--- a/src/test/resources/RaindropsReturnsPlangForMutliplesOfFive.feature
+++ b/src/test/resources/RaindropsReturnsPlangForMutliplesOfFive.feature
@@ -1,11 +1,6 @@
 Feature:  The program returns Plang for input multiples of 5
 
   Scenario: The Raindrops application receives an integer, string, input which is a multiple of 5
-    Given An Integer input of 5
-    When The application is run
-    Then The output should be "Plang"
-
-  Scenario: The Raindrops application receives a non-integer, string, input which is a multiple of 5
-    Given A Double input of 5.00
+    Given An input of "5"
     When The application is run
     Then The output should be "Plang"

--- a/src/test/resources/RaindropsReturnsPlingForMultiplesOfThree.feature
+++ b/src/test/resources/RaindropsReturnsPlingForMultiplesOfThree.feature
@@ -1,11 +1,6 @@
 Feature: The program returns Pling for input multiples of 3
 
   Scenario: The Raindrops application receives an integer, string, input which is a multiple of 3
-    Given An Integer input of 3
-    When The application is run
-    Then The output should be "Pling"
-
-  Scenario: The Raindrops application receives a non-integer, string, input which is a multiple of 3
-    Given A Double input of 3.00
+    Given An input of "3"
     When The application is run
     Then The output should be "Pling"

--- a/src/test/resources/RaindropsReturnsPlongForMultiplesOfSeven.feature
+++ b/src/test/resources/RaindropsReturnsPlongForMultiplesOfSeven.feature
@@ -1,11 +1,6 @@
 Feature: The program returns Plong for input multiples of 7
 
   Scenario: The Raindrops application receives an integer, string, input which is a multiple of 7
-    Given An Integer input of 7
-    When The application is run
-    Then The output should be "Plong"
-
-  Scenario: The Raindrops application receives a non-integer, string, input which is a multiple of 7
-    Given A Double input of 7.00
+    Given An input of "7"
     When The application is run
     Then The output should be "Plong"


### PR DESCRIPTION
Now returns an error message instead of a value. Decision was made in light of the examples presented in the project requirements, where only integer values were presented.

Also altered gherkin statements to reflect this change.

Also an update to a previous commit, the handling of negative value inputs was also decided based upon those examples, which all began with the value of 1.